### PR TITLE
Fix spelling typo; closes #62

### DIFF
--- a/src/fire-server.lua
+++ b/src/fire-server.lua
@@ -369,7 +369,7 @@ end)
 --【 𝗧𝗿𝗶𝗴𝗴𝗲𝗿 𝗠𝗮𝗻𝗮𝗴𝗲𝗺𝗲𝗻𝘁 】--
 local EVENTS = {}
 local isSpamTrigger = false
-if FIREAC.AntiSpamTigger then
+if FIREAC.AntiSpamTrigger then
 	for i = 1, #SpamCheck do
 		local TNAME  =  SpamCheck[i].EVENT
 		local MTIME  =  SpamCheck[i].MAX_TIME


### PR DESCRIPTION
Fixed a spelling mistake in `AntiSpamTrigger`.