### PR TITLE
Fix variable initialization

### DIFF
--- a/src/fire-server.lua
+++ b/src/fire-server.lua
@@ -1289,8 +1289,9 @@ local SV_VEHICLES, SV_PEDS, SV_OBJECT = {}, {}, {}
 -- Event Handler for when an entity is created
 AddEventHandler("entityCreated", function(ENTITY)
     if DoesEntityExist(ENTITY) then
-        local TYPE, OWNER, POPULATION, MODEL, HWID = GetEntityType(ENTITY), NetworkGetFirstEntityOwner(ENTITY),
-            GetEntityPopulationType(ENTITY), GetEntityModel(ENTITY), GetPlayerToken(OWNER, 0)
+        local OWNER = NetworkGetFirstEntityOwner(ENTITY)
+        local TYPE, POPULATION, MODEL, HWID = GetEntityType(ENTITY), GetEntityPopulationType(ENTITY),
+            GetEntityModel(ENTITY), GetPlayerToken(OWNER, 0)
 
         -- Execute actions based on anti-cheat settings
         -- Anti-Blacklist Object Management


### PR DESCRIPTION
Previously the one-liner for multiple variable initializations was referencing other variables in the same one-liner. This isn't allowed in LUA, it will use that variables previous value or `nil` if it didn't exist.

By setting OWNER separately, we can keep the rest of the one-liner.

Fixes #91 